### PR TITLE
Strip extraneous new lines during rich text copy/paste.

### DIFF
--- a/ourchive_app/frontend/templates/chapter_form.html
+++ b/ourchive_app/frontend/templates/chapter_form.html
@@ -229,6 +229,9 @@
 										      ed.getContainer().classList.add("chapter-text-toggle");
 										    });
 										},
+										paste_preprocess: function(editor, args) {
+											args.content = args.content.replaceAll("<br />", "");
+										},
                                         init_instance_callback : function(editor) {
                                         	var chapterText = document.getElementById('chapter_text').value;
                                             editor.setContent(chapterText);


### PR DESCRIPTION
This may cause things to look weird in the rich text box after paste, but I don't know how to fix that part.

It might also affect the formatting of specially formatted text with a lot of newlines.

I am only handling the chapter text rich text box right now, because that's the one most likely to be dealing with copy/paste issues.